### PR TITLE
Removing the line that forces SSLv3

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@ var _ = require('underscore'),
     https   = require('https'),
     request = require('request');
 
-/* fix for SSL ECONNRESET errors under  node 0.10.x */
-https.globalAgent.options.secureProtocol = 'SSLv3_method';
-
 var defaultHost = 'api.mogreet.com',
 	defaultMogreetMethod = 'system.ping',
 	_requestDefaults = {


### PR DESCRIPTION
That fix should no longer be necessary as of now and it does break a lot of APIs that no longer accept SSLv3 since the POODLE vulnerability disclosure. More on POODLE: https://en.wikipedia.org/wiki/POODLE
